### PR TITLE
backstage-docs-syncer-buildkite-plugin - Add catalog info file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-docs-syncer-buildkite-plugin
+  description: Backstage Docs Syncer
+  annotations:
+    github.com/project-slug: https://github.com/blstrco/backstage-docs-syncer-buildkite-plugin
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: Component
+  lifecycle: experimental
+  owner: "linktree"


### PR DESCRIPTION
Adds a basic catalog-info.yaml so it can be seen in backstage