### PR TITLE
backstage-docs-syncer-buildkite-plugin - Add inital docs for backstage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,19 @@
+# backstage-docs-syncer-buildkite-plugin
+
+A plugin to assist in syncing Backstage documents to S3.
+
+This documentation is built using [mkdocs](https://www.mkdocs.org/user-guide/) for [Backstage](https://backstage.io/docs/features/techdocs/techdocs-overview)
+
+
+## Using backstage-docs-syncer-buildkite-plugin
+
+* Todo
+
+# Common tasks
+
+* Todo
+
+## Related Projects
+
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,12 @@
+site_name: "backstage-docs-syncer-buildkite-plugin"
+site_description: "A plugin to assist in syncing Backstage documents to S3."
+
+plugins:
+  - techdocs-core
+
+# ---
+#  With `nav` commented out mkdocs will genetrate a list of all the files in the docs folder automatically
+#  Uncomment it to overwrite this behaviors and build your own navigation tree
+# ---
+# nav:
+#   - Home: index.md


### PR DESCRIPTION
Adds a basic doc folder and config so they can be seen in backstage